### PR TITLE
Enable azure rbac deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ ARM_TEMPLATE_TAG=1.1.0
 RG_TAGS={"Product" : "Teacher services cloud"}
 SERVICE_SHORT=hdoc
 
-development:
+development: test-cluster
 	$(eval include global_config/development.sh)
 
-production:
+production: production-cluster
 	$(eval include global_config/production.sh)
 
 install-terrafile: ## Install terrafile to manage terraform modules
@@ -49,3 +49,15 @@ arm-deployment: set-azure-account
 deploy-arm-resources: arm-deployment
 
 validate-arm-resources: set-what-if arm-deployment
+
+test-cluster:
+	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189t01-tsc-ts-rg)
+	$(eval CLUSTER_NAME=s189t01-tsc-test-aks)
+
+production-cluster:
+	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189p01-tsc-pd-rg)
+	$(eval CLUSTER_NAME=s189p01-tsc-production-aks)
+
+get-cluster-credentials: set-azure-account
+	az aks get-credentials --overwrite-existing -g ${CLUSTER_RESOURCE_GROUP_NAME} -n ${CLUSTER_NAME}
+	kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli)

--- a/terraform/application.tf
+++ b/terraform/application.tf
@@ -35,4 +35,5 @@ module "web_application" {
 
   docker_image           = "quay.io/hedgedoc/hedgedoc:${local.version}"
   web_external_hostnames = [local.main_web_domain]
+  probe_path             = null
 }

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -6,6 +6,7 @@ module "postgres" {
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short
   config_short          = var.config_short
+  service_name          = "hdoc"
 
   cluster_configuration_map = module.cluster_data.configuration_map
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -30,4 +30,13 @@ provider "kubernetes" {
   client_certificate     = module.cluster_data.kubernetes_client_certificate
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+
+  dynamic "exec" {
+    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "kubelogin"
+      args        = module.cluster_data.kubelogin_args
+    }
+  }
 }


### PR DESCRIPTION
## Description

Enable azure rbac on deployment (for when it is enabled in the cluster)

## Trello Card Link

https://trello.com/c/3m8PNLG6/937-enable-azure-rbac-deployment-on-all-services

### Changes proposed in this pull request

Update Makefile and terraform to use rbac if configured for the cluster

Fix a couple of terraform resource settings due to changes in terraform modules
- probe_path and service_name

### Guidance to review

make development get-cluster-credentials
make development terraform-plan
make production get-cluster-credentials
make production terraform-plan
