### PR TITLE
[2179] hedgedoc fix for updated security context

### DIFF
--- a/terraform/application.tf
+++ b/terraform/application.tf
@@ -28,6 +28,8 @@ module "web_application" {
   namespace    = var.namespace
   environment  = var.environment
   service_name = local.service_name
+  run_as_user = "10000"
+  run_as_group = "65534"
 
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name

--- a/terraform/config/development.tfvars.json
+++ b/terraform/config/development.tfvars.json
@@ -3,6 +3,5 @@
     "namespace": "infra",
     "environment": "development",
     "deploy_azure_backing_services": false,
-    "dns_suffix": "test.teacherservices.cloud",
     "enable_postgres_ssl" : false
 }

--- a/terraform/config/production.tfvars.json
+++ b/terraform/config/production.tfvars.json
@@ -2,6 +2,5 @@
     "cluster": "production",
     "namespace": "infra",
     "environment": "production",
-    "deploy_azure_backing_services": true,
-    "dns_suffix": "teacherservices.cloud"
+    "deploy_azure_backing_services": true
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,3 +1,6 @@
 output "url" {
   value = "https://${module.web_application.hostname}/"
 }
+output "exernal_url" {
+  value = "https://${local.main_web_domain}/"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,7 +6,6 @@ variable "azure_resource_prefix" {}
 variable "config_short" {}
 variable "service_short" {}
 variable "deploy_azure_backing_services" { default = true }
-variable "dns_suffix" {}
 variable "rg_name" {}
 variable "enable_postgres_ssl" { default = true }
 
@@ -16,6 +15,6 @@ locals {
 
   azure_credentials = try(jsondecode(var.azure_credentials_json), null)
 
-  main_web_domain   = "hedgedoc.${var.dns_suffix}"
+  main_web_domain   = "hedgedoc.${module.cluster_data.ingress_domain}"
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 }


### PR DESCRIPTION
## Description
The pods security context prevents certain operations like chmod. This is required by the docker entry-point when the pods runs as root.
The workaround here is to run as non-root user. This depends on the module feature being released to stable.

## How to review
Run terraform-plan. The app should start.