### PR TITLE
feat(2434): ts-hedgedoc: AKS containers - run as non-root user

### DIFF
--- a/terraform/application.tf
+++ b/terraform/application.tf
@@ -6,6 +6,7 @@ module "application_configuration" {
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short
   config_short          = var.config_short
+  run_as_non_root       = var.run_as_non_root
 
   config_variables = {
     CMD_DOMAIN            = local.main_web_domain
@@ -25,11 +26,12 @@ module "web_application" {
 
   is_web = true
 
-  namespace    = var.namespace
-  environment  = var.environment
-  service_name = local.service_name
-  run_as_user = "10000"
-  run_as_group = "65534"
+  namespace       = var.namespace
+  environment     = var.environment
+  service_name    = local.service_name
+  run_as_user     = "10000"
+  run_as_group    = "65534"
+  run_as_non_root = var.run_as_non_root
 
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name


### PR DESCRIPTION
### Context

ensure hedgedoc is running as a non-root user

https://trello.com/c/NYHOtlR5/2434-blocked-lose-data-security-aks-containers-run-as-non-root-user-ts-hedgedoc

#### Why are we making this change?

improve security - adopt AKS containers best practice 

####  What has been changed?
- modified terraform to enforce container running as non-root user (Note: container is already running as non-root-user but it is not currently enforced via security context within k8s deployment)

####  Evidence for testing:-

- added toggle variable in terraform:-

<img width="668" height="431" alt="Screenshot from 2025-08-19 09-56-39" src="https://github.com/user-attachments/assets/25ade764-ef3e-404a-ae20-73a1ec620880" />

- [TEST Hedgedoc site](https://hedgedoc.test.teacherservices.cloud/) still available

- exec onto pod - running as user hedgedoc (uid 10000)
<img width="1268" height="428" alt="Screenshot from 2025-08-19 10-11-53" src="https://github.com/user-attachments/assets/fec84419-4c23-472e-be16-58111d1c5bc5" />
<img width="1272" height="58" alt="Screenshot from 2025-08-19 10-09-20" src="https://github.com/user-attachments/assets/c7ec14fb-d830-4ea9-99a1-23b2f83826bd" />

Note: hedgedoc image is pulled from quay.io and is controlled externally, but the user is non-root so we only need to enforce non-root in terraform via security context setting within k8s deployment resource; its already in place in this externally built docker image:-
<img width="1355" height="60" alt="Screenshot from 2025-08-19 10-14-20" src="https://github.com/user-attachments/assets/faee7f04-72b6-4f8a-ba83-5f1f40d1cb55" />

 